### PR TITLE
update init import so no need for hpc.hpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# hpc
+
+Simulation package for heterodyne phase camera

--- a/hpc/__init__.py
+++ b/hpc/__init__.py
@@ -7,4 +7,4 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 
-import hpc.hpc as hpc
+from hpc.hpc import *

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(name='hpc',
       version='0.1',
       description='Simulation package for heterodyne phase camera',
-      long_description=open('README.txt').read(),
+      long_description=open('README.md').read(),
       install_requires=['numpy','pykat','matplotlib'],
       classifiers=[
             'Development Status :: 1 - Planning',


### PR DESCRIPTION
previous __init__.py used import hpc.hpc as hpc, which means you'd have to use hpc.hpc to call functions, now has from hpc.hpc import * which means you only need use hpc to call functions:

previously in notebook:
import hpc
hpc.hpc.whichever_function_you_choose

now in notebook:
import hpc
hpc.whichever_function_you_choose